### PR TITLE
Add Inteless PV custom component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-# test
-testowe repo
+# Inteless PV Home Assistant Example
+
+This repository provides a minimal custom component for Home Assistant that
+connects to the Inteless PV open API. The integration logs in using the
+`oauth/token` endpoint and exposes a sensor showing the current plant power.
+
+Copy the `custom_components/inteless_pv` folder into your Home Assistant
+configuration directory to try it out.

--- a/custom_components/inteless_pv/__init__.py
+++ b/custom_components/inteless_pv/__init__.py
@@ -1,0 +1,95 @@
+"""Inteless PV integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import aiohttp
+import async_timeout
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import (
+    API_BASE,
+    CLIENT_ID,
+    CONF_PASSWORD,
+    CONF_PLANT_ID,
+    CONF_USERNAME,
+    DOMAIN,
+    PLATFORMS,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class IntelessPVClient:
+    """Client for communicating with Inteless PV API."""
+
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        plant_id: str,
+    ) -> None:
+        self._session = session
+        self._username = username
+        self._password = password
+        self._plant_id = plant_id
+        self._token: str | None = None
+
+    async def async_login(self) -> None:
+        """Log in and store the access token."""
+        url = f"{API_BASE}/oauth/token"
+        payload = {
+            "username": self._username,
+            "password": self._password,
+            "grant_type": "password",
+            "client_id": CLIENT_ID,
+        }
+        async with async_timeout.timeout(15):
+            resp = await self._session.post(url, data=payload)
+            data: dict[str, Any] = await resp.json()
+        self._token = data.get("access_token")
+        if not self._token:
+            raise RuntimeError("Login failed")
+
+    async def async_get_realtime(self) -> dict[str, Any]:
+        """Return realtime data for plant."""
+        if not self._token:
+            await self.async_login()
+        headers = {"Authorization": f"Bearer {self._token}"}
+        url = f"{API_BASE}/plant/{self._plant_id}/realtime"
+        async with async_timeout.timeout(15):
+            resp = await self._session.get(url, headers=headers)
+            data: dict[str, Any] = await resp.json()
+        return data.get("data", {})
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Inteless PV integration from a config entry."""
+    session = async_get_clientsession(hass)
+    client = IntelessPVClient(
+        session,
+        entry.data[CONF_USERNAME],
+        entry.data[CONF_PASSWORD],
+        entry.data[CONF_PLANT_ID],
+    )
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = client
+
+    for platform in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/custom_components/inteless_pv/const.py
+++ b/custom_components/inteless_pv/const.py
@@ -1,0 +1,9 @@
+DOMAIN = "inteless_pv"
+PLATFORMS = ["sensor"]
+
+CONF_USERNAME = "username"
+CONF_PASSWORD = "password"
+CONF_PLANT_ID = "plant_id"
+
+API_BASE = "https://openapi.inteless.com/v1"
+CLIENT_ID = "csp-web"

--- a/custom_components/inteless_pv/manifest.json
+++ b/custom_components/inteless_pv/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "inteless_pv",
+  "name": "Inteless PV",
+  "version": "0.1.0",
+  "documentation": "https://github.com/yourname/inteless_pv",
+  "requirements": ["aiohttp"],
+  "codeowners": ["@twoj_nick"]
+}

--- a/custom_components/inteless_pv/sensor.py
+++ b/custom_components/inteless_pv/sensor.py
@@ -1,0 +1,57 @@
+"""Sensor platform for Inteless PV."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+SCAN_INTERVAL = timedelta(minutes=5)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
+    """Set up Inteless PV sensors."""
+    client = hass.data[DOMAIN][entry.entry_id]
+
+    async def async_update_data():
+        try:
+            return await client.async_get_realtime()
+        except Exception as err:
+            raise UpdateFailed(f"Error fetching data: {err}") from err
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="inteless_pv",
+        update_method=async_update_data,
+        update_interval=SCAN_INTERVAL,
+    )
+    await coordinator.async_config_entry_first_refresh()
+
+    async_add_entities([IntelessPVPowerSensor(coordinator)])
+
+
+class IntelessPVPowerSensor(SensorEntity):
+    """Representation of current power sensor."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator) -> None:
+        self.coordinator = coordinator
+        self._attr_name = "Inteless PV Power"
+        self._attr_unique_id = "inteless_pv_power"
+
+    @property
+    def native_value(self) -> float | None:
+        return self.coordinator.data.get("pac")
+
+    @property
+    def unit_of_measurement(self) -> str:
+        return "kW"
+
+    async def async_update(self) -> None:
+        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## Summary
- add Inteless PV custom component for Home Assistant
- fetch plant realtime data and expose power sensor

## Testing
- `python -m py_compile custom_components/inteless_pv/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b06ad5b444832cbe51fc9ea3184556